### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Templates/Be.Vlaanderen.Basisregisters.Registry/docs/ExampleRegistry.Structurizr/ExampleRegistry.Structurizr.csproj
+++ b/src/Be.Vlaanderen.Basisregisters.Templates/Be.Vlaanderen.Basisregisters.Registry/docs/ExampleRegistry.Structurizr/ExampleRegistry.Structurizr.csproj
@@ -3,7 +3,15 @@
 
   <PropertyGroup>
     <DisableImplicitFrameworkReferences>False</DisableImplicitFrameworkReferences>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <Content Include="appsettings.json" CopyToOutputDirectory="Always" />

--- a/src/Be.Vlaanderen.Basisregisters.Templates/Be.Vlaanderen.Basisregisters.Registry/src/EF.MigrationsHelper/EF.MigrationHelper.csproj
+++ b/src/Be.Vlaanderen.Basisregisters.Templates/Be.Vlaanderen.Basisregisters.Registry/src/EF.MigrationsHelper/EF.MigrationHelper.csproj
@@ -14,7 +14,15 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\ExampleRegistry.Projections.Api\ExampleRegistry.Projections.Api.csproj" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
